### PR TITLE
feat: Add most-popular as a talent build source

### DIFF
--- a/src/Main.lua
+++ b/src/Main.lua
@@ -37,12 +37,41 @@ addon.TabContent = TabContent
 local ButtonFix = addon.ButtonFix or {}
 addon.ButtonFix = ButtonFix
 
+-- Tab configuration: index -> source name and tab creator
+local TAB_SOURCES = {
+    [1] = { source = "archon",  label = "Archon",  creator = "CreateArchonTab" },
+    [2] = { source = "wowhead", label = "Wowhead", creator = "CreateWowheadTab" },
+}
+
+-- Source -> categories and their dropdown/editbox naming conventions
+local SOURCE_CATEGORIES = {
+    archon = {
+        { category = "mythic",      prefix = "archonMythic",     initFunc = "InitializeArchonMythicDropdown" },
+        { category = "heroic_raid", prefix = "archonHeroicRaid", initFunc = "InitializeArchonHeroicRaidDropdown" },
+        { category = "mythic_raid", prefix = "archonMythicRaid", initFunc = "InitializeArchonMythicRaidDropdown" },
+    },
+    wowhead = {
+        { category = "mythic", prefix = "wowheadMythic", initFunc = "InitializeWowheadMythicDropdown" },
+        { category = "raid",   prefix = "wowheadRaid",   initFunc = "InitializeWowheadRaidDropdown" },
+        { category = "misc",   prefix = "wowheadMisc",   initFunc = "InitializeWowheadMiscDropdown" },
+    },
+}
+
 local function CheckDataAddonLoaded()
     if not PeaversTalentsData then
         Utils.Debug("PeaversTalentsData addon not found!")
         return false
     end
     return true
+end
+
+local function TableContains(tbl, value)
+    for _, v in pairs(tbl) do
+        if v == value then
+            return true
+        end
+    end
+    return false
 end
 
 local function CreateExportDialog()
@@ -57,10 +86,26 @@ local function CreateExportDialog()
     dialog.TitleBg = UIComponents.CreateTitleBackground(dialog)
     dialog.CloseButton = UIComponents.CreateCloseButton(dialog)
 
+    -- Create tabs
+    dialog.Tabs = {}
     dialog.TabContents = {}
-    dialog.TabContents[1] = UIComponents.CreateTabContent(dialog)
+
+    for i, tabInfo in ipairs(TAB_SOURCES) do
+        dialog.Tabs[i] = UIComponents.CreateTab(dialog, i, tabInfo.label)
+        dialog.TabContents[i] = UIComponents.CreateTabContent(dialog)
+    end
+
+    PanelTemplates_SetNumTabs(dialog, #TAB_SOURCES)
+    PanelTemplates_SetTab(dialog, 1)
+
+    -- Show first tab, create content for all tabs
     dialog.TabContents[1]:Show()
-    TabContent.CreateArchonTab(dialog, dialog.TabContents[1])
+    for i, tabInfo in ipairs(TAB_SOURCES) do
+        TabContent[tabInfo.creator](dialog, dialog.TabContents[i])
+        if i > 1 then
+            dialog.TabContents[i]:Hide()
+        end
+    end
 
     dialog:SetMovable(true)
     dialog:EnableMouse(true)
@@ -80,31 +125,58 @@ local function CreateExportDialog()
         local savedSource, savedCategory, savedBuildKey = addon.LocalStorage.LoadSelection()
         Utils.Debug("Loaded saved selection:", savedSource, savedCategory, savedBuildKey)
 
-        local builds = PeaversTalentsData.API.GetBuilds(classID, specID, "archon")
-        if builds and #builds > 0 then
-            for _, category in ipairs({"mythic", "heroic_raid", "mythic_raid"}) do
-                local dropdownName = "archon" .. category:gsub("_", ""):gsub("^%l", string.upper):gsub("raid", "Raid") .. "Dropdown"
-                local dropdown = dialog[dropdownName]
-                if dropdown then
-                    local initFuncName = "InitializeArchon" .. category:gsub("_", ""):gsub("^%l", string.upper):gsub("raid", "Raid") .. "Dropdown"
-                    UIDropDownMenu_Initialize(dropdown, addon.DropdownManager[initFuncName])
+        local sources = PeaversTalentsData.API.GetSources()
 
-                    if savedSource == "archon" and savedCategory == category then
-                        Utils.Debug("Found matching dropdown for saved selection:", dropdownName)
-                        for _, build in ipairs(builds) do
-                            if build.dungeonID == savedBuildKey then
-                                local editBoxName = "archon" .. category:gsub("_", ""):gsub("^%l", string.upper):gsub("raid", "Raid") .. "Edit"
-                                local editBox = dialog[editBoxName]
-                                if editBox then
-                                    editBox:SetText(build.talentString or "")
-                                    editBox:SetCursorPosition(0)
-                                    UIDropDownMenu_SetText(dropdown, build.label or tostring(savedBuildKey))
+        -- Initialize dropdowns for all sources that have data
+        for sourceName, categories in pairs(SOURCE_CATEGORIES) do
+            if TableContains(sources, sourceName) then
+                local builds = PeaversTalentsData.API.GetBuilds(classID, specID, sourceName)
+                if builds and #builds > 0 then
+                    for _, cat in ipairs(categories) do
+                        local dropdown = dialog[cat.prefix .. "Dropdown"]
+                        if dropdown and addon.DropdownManager[cat.initFunc] then
+                            UIDropDownMenu_Initialize(dropdown, addon.DropdownManager[cat.initFunc])
+
+                            -- Restore saved selection if it matches
+                            if savedSource == sourceName and savedCategory == cat.category then
+                                for _, build in ipairs(builds) do
+                                    if build.dungeonID == savedBuildKey then
+                                        local editBox = dialog[cat.prefix .. "Edit"]
+                                        if editBox then
+                                            editBox:SetText(build.talentString or "")
+                                            editBox:SetCursorPosition(0)
+                                            UIDropDownMenu_SetText(dropdown, build.label or tostring(savedBuildKey))
+                                        end
+                                        break
+                                    end
                                 end
-                                break
                             end
                         end
                     end
                 end
+            end
+        end
+
+        -- Show/hide tabs based on data availability, select saved source tab
+        for i, tabInfo in ipairs(TAB_SOURCES) do
+            local hasData = TableContains(sources, tabInfo.source) and
+                    PeaversTalentsData.API.GetBuilds(classID, specID, tabInfo.source) and
+                    #PeaversTalentsData.API.GetBuilds(classID, specID, tabInfo.source) > 0
+
+            if hasData then
+                dialog.Tabs[i]:Show()
+                if tabInfo.source == savedSource then
+                    PanelTemplates_SetTab(dialog, i)
+                    for j, content in pairs(dialog.TabContents) do
+                        if j == i then
+                            content:Show()
+                        else
+                            content:Hide()
+                        end
+                    end
+                end
+            else
+                dialog.Tabs[i]:Hide()
             end
         end
 
@@ -138,22 +210,22 @@ PeaversCommons.Events:Init(addonName, function()
     if addon.ConfigUI and addon.ConfigUI.Initialize then
         addon.ConfigUI:Initialize()
     end
-    
+
     Utils.Debug("Initializing ButtonFix module")
     if addon.ButtonFix and addon.ButtonFix.Initialize then
         addon.ButtonFix:Initialize()
     end
-    
+
     SLASH_PEAVERSTALENTS1 = "/peaverstalents"
     SLASH_PEAVERSTALENTS2 = "/pt"
     SlashCmdList["PEAVERSTALENTS"] = function()
         addon.ShowExportDialog()
     end
-    
+
     PeaversCommons.Events:RegisterEvent("PLAYER_ENTERING_WORLD", function()
         Utils.Debug("Player entering world")
     end)
-    
+
     C_Timer.After(0.5, function()
         PeaversCommons.SettingsUI:CreateSettingsPages(
             addon,

--- a/src/UI/DropdownManager.lua
+++ b/src/UI/DropdownManager.lua
@@ -104,4 +104,17 @@ function DropdownManager.InitializeArchonMythicRaidDropdown(frame, level)
 	InitializeDropdown(frame, level, "archon", "mythic_raid", addon.exportDialog.archonMythicRaidEdit, addon.exportDialog.archonMythicRaidNewLabel)
 end
 
+-- Wowhead dropdown initializers
+function DropdownManager.InitializeWowheadMythicDropdown(frame, level)
+	InitializeDropdown(frame, level, "wowhead", "mythic", addon.exportDialog.wowheadMythicEdit, addon.exportDialog.wowheadMythicNewLabel)
+end
+
+function DropdownManager.InitializeWowheadRaidDropdown(frame, level)
+	InitializeDropdown(frame, level, "wowhead", "raid", addon.exportDialog.wowheadRaidEdit, addon.exportDialog.wowheadRaidNewLabel)
+end
+
+function DropdownManager.InitializeWowheadMiscDropdown(frame, level)
+	InitializeDropdown(frame, level, "wowhead", "misc", addon.exportDialog.wowheadMiscEdit, addon.exportDialog.wowheadMiscNewLabel)
+end
+
 return DropdownManager

--- a/src/UI/TabContent.lua
+++ b/src/UI/TabContent.lua
@@ -12,29 +12,56 @@ function TabContent.CreateEditBox(parent, name)
 	return editBox
 end
 
--- Configuration for Archon tab sections
-local TAB_CONFIG = {
-	sections = {
-		{
-			name = "Mythic+",
-			dropdownInitializer = "InitializeArchonMythicDropdown",
-			editBoxPrefix = "archonMythic",
-			source = "archon",
-			category = "mythic"
-		},
-		{
-			name = "Heroic Raid",
-			dropdownInitializer = "InitializeArchonHeroicRaidDropdown",
-			editBoxPrefix = "archonHeroicRaid",
-			source = "archon",
-			category = "heroic_raid"
-		},
-		{
-			name = "Mythic Raid",
-			dropdownInitializer = "InitializeArchonMythicRaidDropdown",
-			editBoxPrefix = "archonMythicRaid",
-			source = "archon",
-			category = "mythic_raid"
+-- Configuration for different tab types
+local TAB_CONFIGS = {
+	archon = {
+		sections = {
+			{
+				name = "Mythic+",
+				dropdownInitializer = "InitializeArchonMythicDropdown",
+				editBoxPrefix = "archonMythic",
+				source = "archon",
+				category = "mythic"
+			},
+			{
+				name = "Heroic Raid",
+				dropdownInitializer = "InitializeArchonHeroicRaidDropdown",
+				editBoxPrefix = "archonHeroicRaid",
+				source = "archon",
+				category = "heroic_raid"
+			},
+			{
+				name = "Mythic Raid",
+				dropdownInitializer = "InitializeArchonMythicRaidDropdown",
+				editBoxPrefix = "archonMythicRaid",
+				source = "archon",
+				category = "mythic_raid"
+			}
+		}
+	},
+	wowhead = {
+		sections = {
+			{
+				name = "Mythic+",
+				dropdownInitializer = "InitializeWowheadMythicDropdown",
+				editBoxPrefix = "wowheadMythic",
+				source = "wowhead",
+				category = "mythic"
+			},
+			{
+				name = "Raid",
+				dropdownInitializer = "InitializeWowheadRaidDropdown",
+				editBoxPrefix = "wowheadRaid",
+				source = "wowhead",
+				category = "raid"
+			},
+			{
+				name = "Misc",
+				dropdownInitializer = "InitializeWowheadMiscDropdown",
+				editBoxPrefix = "wowheadMisc",
+				source = "wowhead",
+				category = "misc"
+			}
 		}
 	}
 }
@@ -90,9 +117,26 @@ local function CreateSection(dialog, tab, section, prevElement, isFirst)
 	return editBox
 end
 
--- Create the Archon tab content
+-- Generic function to create any type of tab
+local function CreateTab(dialog, tab, tabType)
+	local config = TAB_CONFIGS[tabType]
+	if not config then
+		error("Unknown tab type: " .. tostring(tabType))
+		return
+	end
+
+	local prevElement = nil
+	for i, section in ipairs(config.sections) do
+		prevElement = CreateSection(dialog, tab, section, prevElement, i == 1)
+	end
+
+	local instructionsText = tab:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+	instructionsText:SetPoint("BOTTOM", tab, "BOTTOM", 0, 55)
+	instructionsText:SetText("Updated " .. Utils.GetFormattedUpdate(config.sections[1].source))
+	instructionsText:SetJustifyH("CENTER")
+end
+
 function TabContent.CreateArchonTab(dialog, tab)
-	-- Check maintenance mode first
 	if addon.Config.MAINTENANCE_MODE then
 		local messageText = tab:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
 		messageText:SetPoint("CENTER", tab, "CENTER", 0, 20)
@@ -102,15 +146,11 @@ function TabContent.CreateArchonTab(dialog, tab)
 		return
 	end
 
-	local prevElement = nil
-	for i, section in ipairs(TAB_CONFIG.sections) do
-		prevElement = CreateSection(dialog, tab, section, prevElement, i == 1)
-	end
+	CreateTab(dialog, tab, "archon")
+end
 
-	local instructionsText = tab:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-	instructionsText:SetPoint("BOTTOM", tab, "BOTTOM", 0, 55)
-	instructionsText:SetText("Updated " .. Utils.GetFormattedUpdate("archon"))
-	instructionsText:SetJustifyH("CENTER")
+function TabContent.CreateWowheadTab(dialog, tab)
+	CreateTab(dialog, tab, "wowhead")
 end
 
 return TabContent

--- a/src/Utils/ConfigUI.lua
+++ b/src/Utils/ConfigUI.lua
@@ -50,10 +50,10 @@ function ConfigUI:InitializeOptions()
     infoText:SetJustifyH("LEFT")
     infoText:SetSpacing(2)
     infoText:SetText(
-        "This addon adds a 'Builds' button to your talent UI that allows you to import talent builds from Archon.\n\n" ..
+        "This addon adds a 'Builds' button to your talent UI that allows you to import talent builds from Archon and Wowhead.\n\n" ..
         "1. Open your talent UI (press 'N' by default)\n" ..
         "2. Click the 'Builds' button next to the search box\n" ..
-        "3. Choose a build category (Mythic+, Heroic Raid, Mythic Raid)\n" ..
+        "3. Switch between sources using the tabs at the bottom\n" ..
         "4. Select a specific build from the dropdown\n" ..
         "5. Click 'Import' to apply the build to your character"
     )


### PR DESCRIPTION
## Summary
- Restore tab-based UI with top-players and most-popular tabs
- most-popular tab shows Mythic+, Raid, and Misc build categories
- Tabs dynamically show/hide based on data availability from PeaversTalentsData
- Dropdown initializers and tab content for both sources

## Context
The new `most-popular-module` Lambda scraper fetches curated talent builds from most-popular guide pages and generates `MostPopularMythicDB.lua`, `MostPopularRaidDB.lua`, and `MostPopularMiscDB.lua` in PeaversTalentsData. This PR adds the UI to consume that data.

## Test plan
- [ ] Open talent UI in-game, verify both top-players and most-popular tabs appear
- [ ] Verify most-popular tab shows Mythic+, Raid, Misc dropdowns with builds
- [ ] Verify tab switching works correctly
- [ ] Verify saved selections restore on dialog reopen